### PR TITLE
Expand the items stored in wardrobe outfits

### DIFF
--- a/src/client/controls/CheckBoxButton.tsx
+++ b/src/client/controls/CheckBoxButton.tsx
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
     container: {
         flexDirection: "row",
         alignItems: "center",
-        padding: 4,
+        padding: 3,
     },
     caption: {
         fontSize: 16,

--- a/src/client/controls/ItemSelector.tsx
+++ b/src/client/controls/ItemSelector.tsx
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
     },
     titleBar: {
         justifyContent: "center",
-        minHeight: 50,
+        minHeight: 40,
     },
     title: {
         textAlign: "center",

--- a/src/client/dialogs/WardrobeDialog.tsx
+++ b/src/client/dialogs/WardrobeDialog.tsx
@@ -7,10 +7,10 @@ import TouchButton from "../controls/TouchButton";
 import Interaction from "../Interaction";
 import OutfitMemberSelector from "../items/OutfitMemberSelector";
 
+import Equipper from "../../items/Equipper";
 import IOutfit from "../../items/IOutfit";
-import OutfitChecklist from "../../items/OutfitChecklist";
+import OutfitMaker from "../../items/OutfitMaker";
 import { OutfitSlot } from "../../items/OutfitSlot";
-import Outfitter from "../../items/Outfitter";
 import WardrobeStore from "../../store/WardrobeStore";
 import IHabiticaData from "../../userData/IHabiticaData";
 
@@ -23,7 +23,7 @@ interface IState {
     wardrobe?: IOutfit[];
     useCostume: boolean;
     outfitNameInput: string;
-    outfitChecklist: OutfitChecklist;
+    outfitMaker: OutfitMaker;
     loading: boolean;
     showAddForm: boolean;
     isResolvedMessage?: string;
@@ -35,7 +35,7 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         this.state = {
             useCostume: true,
             outfitNameInput: "",
-            outfitChecklist: new OutfitChecklist(),
+            outfitMaker: new OutfitMaker(this.props.userData),
             loading: true,
             showAddForm: false,
         };
@@ -94,7 +94,7 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         return (
             <>
                 <Input placeholder="Outfit name" onChangeText={outfitNameInput => this.setState({ outfitNameInput })}/>
-                <OutfitMemberSelector updateGearSet={this.updateGearSet} gearChecklist={this.state.outfitChecklist}/>
+                <OutfitMemberSelector updateGearSet={this.updateGearSet} gearChecklist={this.state.outfitMaker!.checklist}/>
             </>
         );
     }
@@ -103,8 +103,8 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         this.setState({ loading: true });
         const newOutfit = this.state.wardrobe!.find(o => o.name === outfitName);
         if (newOutfit) {
-            const outfitter = new Outfitter(newOutfit, this.state.useCostume, await this.props.userData);
-            this.setState({ loading: false, isResolvedMessage: await outfitter.equipAll() });
+            const equipper = new Equipper(newOutfit, this.state.useCostume, await this.props.userData);
+            this.setState({ loading: false, isResolvedMessage: await equipper.equipAll() });
         } else {
             this.setState({ loading: false, isResolvedMessage: "Outfit not found." });
         }
@@ -126,35 +126,16 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         if (nameValidationError) {
             Alert.alert("Invalid input", nameValidationError);
         } else {
-            const data = (await this.props.userData);
-            const rawGearSet = data.items.gear[this.state.useCostume ? "costume" : "equipped"];
-            const checklist = this.state.outfitChecklist;
-            const outfit: IOutfit = {
-                name,
-                gearSet: {
-                    armor: checklist.armor ? rawGearSet.armor : undefined,
-                    head: checklist.head ? rawGearSet.head : undefined,
-                    shield: checklist.shield ? rawGearSet.shield : undefined,
-                    body: checklist.body ? rawGearSet.body : undefined,
-                    weapon: checklist.weapon ? rawGearSet.weapon : undefined,
-                    eyewear: checklist.eyewear ? rawGearSet.eyewear : undefined,
-                    headAccessory: checklist.headAccessory ? rawGearSet.headAccessory : undefined,
-                    back: checklist.back ? rawGearSet.back : undefined,
-                },
-                skin: checklist.skin ? data.preferences.skin : undefined,
-                background: checklist.background ? data.preferences.background : undefined,
-                pet: checklist.pet ? data.items.currentPet : undefined,
-                mount: checklist.mount ? data.items.currentMount : undefined,
-            };
-            await WardrobeStore.add(outfit);
-            this.setState({ isResolvedMessage: `Successfully added ${name} to your wardrobe.` });
+            this.setState({ loading: true });
+            const isResolvedMessage = await this.state.outfitMaker.save(name, this.state.useCostume);
+            this.setState({ loading: false, isResolvedMessage });
         }
     }
 
     private updateGearSet = async (slot: OutfitSlot, value: boolean) => {
-        const outfitSlotChecklist = this.state.outfitChecklist;
-        outfitSlotChecklist[slot] = value;
-        this.setState({ outfitChecklist: outfitSlotChecklist });
+        const outfitMaker = this.state.outfitMaker;
+        outfitMaker.checklist[slot] = value;
+        this.setState({ outfitMaker });
     }
 
     private validateOutfitName(outfitName: string): string | undefined {

--- a/src/client/dialogs/WardrobeDialog.tsx
+++ b/src/client/dialogs/WardrobeDialog.tsx
@@ -7,9 +7,9 @@ import TouchButton from "../controls/TouchButton";
 import Interaction from "../Interaction";
 import OutfitMemberSelector from "../items/OutfitMemberSelector";
 
-import GearChecklist from "../../items/GearChecklist";
-import { GearSlot } from "../../items/GearSlot";
 import IOutfit from "../../items/IOutfit";
+import OutfitChecklist from "../../items/OutfitChecklist";
+import { OutfitSlot } from "../../items/OutfitSlot";
 import Outfitter from "../../items/Outfitter";
 import WardrobeStore from "../../store/WardrobeStore";
 import IHabiticaData from "../../userData/IHabiticaData";
@@ -23,7 +23,7 @@ interface IState {
     wardrobe?: IOutfit[];
     useCostume: boolean;
     outfitNameInput: string;
-    outfitSlotChecklist: GearChecklist;
+    outfitChecklist: OutfitChecklist;
     loading: boolean;
     showAddForm: boolean;
     isResolvedMessage?: string;
@@ -35,7 +35,7 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         this.state = {
             useCostume: true,
             outfitNameInput: "",
-            outfitSlotChecklist: new GearChecklist(),
+            outfitChecklist: new OutfitChecklist(),
             loading: true,
             showAddForm: false,
         };
@@ -94,7 +94,7 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         return (
             <>
                 <Input placeholder="Outfit name" onChangeText={outfitNameInput => this.setState({ outfitNameInput })}/>
-                <OutfitMemberSelector updateGearSet={this.updateGearSet} gearChecklist={this.state.outfitSlotChecklist}/>
+                <OutfitMemberSelector updateGearSet={this.updateGearSet} gearChecklist={this.state.outfitChecklist}/>
             </>
         );
     }
@@ -126,27 +126,35 @@ export class WardrobeDialog extends React.Component<IProps, IState> {
         if (nameValidationError) {
             Alert.alert("Invalid input", nameValidationError);
         } else {
-            const rawGearSet = (await this.props.userData).items.gear[this.state.useCostume ? "costume" : "equipped"];
-            const checklist = this.state.outfitSlotChecklist;
-            const gearSet = {
-                armor: checklist.armor ? rawGearSet.armor : undefined,
-                head: checklist.head ? rawGearSet.head : undefined,
-                shield: checklist.shield ? rawGearSet.shield : undefined,
-                body: checklist.body ? rawGearSet.body : undefined,
-                weapon: checklist.weapon ? rawGearSet.weapon : undefined,
-                eyewear: checklist.eyewear ? rawGearSet.eyewear : undefined,
-                headAccessory: checklist.headAccessory ? rawGearSet.headAccessory : undefined,
-                back: checklist.back ? rawGearSet.back : undefined,
+            const data = (await this.props.userData);
+            const rawGearSet = data.items.gear[this.state.useCostume ? "costume" : "equipped"];
+            const checklist = this.state.outfitChecklist;
+            const outfit: IOutfit = {
+                name,
+                gearSet: {
+                    armor: checklist.armor ? rawGearSet.armor : undefined,
+                    head: checklist.head ? rawGearSet.head : undefined,
+                    shield: checklist.shield ? rawGearSet.shield : undefined,
+                    body: checklist.body ? rawGearSet.body : undefined,
+                    weapon: checklist.weapon ? rawGearSet.weapon : undefined,
+                    eyewear: checklist.eyewear ? rawGearSet.eyewear : undefined,
+                    headAccessory: checklist.headAccessory ? rawGearSet.headAccessory : undefined,
+                    back: checklist.back ? rawGearSet.back : undefined,
+                },
+                skin: checklist.skin ? data.preferences.skin : undefined,
+                background: checklist.background ? data.preferences.background : undefined,
+                pet: checklist.pet ? data.items.currentPet : undefined,
+                mount: checklist.mount ? data.items.currentMount : undefined,
             };
-            await WardrobeStore.add({ name, gearSet });
+            await WardrobeStore.add(outfit);
             this.setState({ isResolvedMessage: `Successfully added ${name} to your wardrobe.` });
         }
     }
 
-    private updateGearSet = async (slot: GearSlot, value: boolean) => {
-        const outfitSlotChecklist = this.state.outfitSlotChecklist;
+    private updateGearSet = async (slot: OutfitSlot, value: boolean) => {
+        const outfitSlotChecklist = this.state.outfitChecklist;
         outfitSlotChecklist[slot] = value;
-        this.setState({ outfitSlotChecklist });
+        this.setState({ outfitChecklist: outfitSlotChecklist });
     }
 
     private validateOutfitName(outfitName: string): string | undefined {

--- a/src/client/items/OutfitMemberSelector.tsx
+++ b/src/client/items/OutfitMemberSelector.tsx
@@ -24,17 +24,17 @@ export default class OutfitMemberSelector extends React.Component<IProps> {
                         {this.renderMemberCheckBox("Off hand", "shield")}
                         {this.renderMemberCheckBox("Head gear", "head")}
                         {this.renderMemberCheckBox("Armor", "armor")}
-                        {this.renderMemberCheckBox("Skin", "skin")}
-                        {this.renderMemberCheckBox("Pet", "pet")}
-                        {this.renderMemberCheckBox("Hair", "hair")}
-                    </View>
-                    <View style={styles.column}>
                         {this.renderMemberCheckBox("Head accessory", "headAccessory")}
-                        {this.renderMemberCheckBox("Eyewear", "eyewear")}
                         {this.renderMemberCheckBox("Body accessory", "body")}
                         {this.renderMemberCheckBox("Back accessory", "back")}
+                    </View>
+                    <View style={styles.column}>
+                        {this.renderMemberCheckBox("Eyewear", "eyewear")}
+                        {this.renderMemberCheckBox("Skin", "skin")}
+                        {this.renderMemberCheckBox("Hair", "hair")}
                         {this.renderMemberCheckBox("Background", "background")}
                         {this.renderMemberCheckBox("Mount", "mount")}
+                        {this.renderMemberCheckBox("Pet", "pet")}
                     </View>
                 </View>
             </View>
@@ -54,11 +54,11 @@ const styles = StyleSheet.create({
         justifyContent: "center",
         alignSelf: "stretch",
         alignItems: "center",
-        marginTop: 8,
+        marginTop: 4,
     },
     titleBar: {
         justifyContent: "center",
-        minHeight: 50,
+        minHeight: 40,
     },
     title: {
         textAlign: "center",
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
     },
     columnManager: {
         flexDirection: "row",
-        marginBottom: 8,
+        marginBottom: 6,
     },
     column: {
         marginLeft: 8,

--- a/src/client/items/OutfitMemberSelector.tsx
+++ b/src/client/items/OutfitMemberSelector.tsx
@@ -26,6 +26,7 @@ export default class OutfitMemberSelector extends React.Component<IProps> {
                         {this.renderMemberCheckBox("Armor", "armor")}
                         {this.renderMemberCheckBox("Skin", "skin")}
                         {this.renderMemberCheckBox("Pet", "pet")}
+                        {this.renderMemberCheckBox("Hair", "hair")}
                     </View>
                     <View style={styles.column}>
                         {this.renderMemberCheckBox("Head accessory", "headAccessory")}

--- a/src/client/items/OutfitMemberSelector.tsx
+++ b/src/client/items/OutfitMemberSelector.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
-import GearChecklist from "../../items/GearChecklist";
-import { GearSlot } from "../../items/GearSlot";
+import OutfitChecklist from "../../items/OutfitChecklist";
+import { OutfitSlot } from "../../items/OutfitSlot";
 
 import CheckBoxButton from "../controls/CheckBoxButton";
 
 interface IProps {
-    gearChecklist: GearChecklist;
-    updateGearSet: (slot: GearSlot, value: boolean) => void;
+    gearChecklist: OutfitChecklist;
+    updateGearSet: (slot: OutfitSlot, value: boolean) => void;
 }
 
 export default class OutfitMemberSelector extends React.Component<IProps> {
@@ -24,19 +24,23 @@ export default class OutfitMemberSelector extends React.Component<IProps> {
                         {this.renderMemberCheckBox("Off hand", "shield")}
                         {this.renderMemberCheckBox("Head gear", "head")}
                         {this.renderMemberCheckBox("Armor", "armor")}
+                        {this.renderMemberCheckBox("Skin", "skin")}
+                        {this.renderMemberCheckBox("Pet", "pet")}
                     </View>
                     <View style={styles.column}>
                         {this.renderMemberCheckBox("Head accessory", "headAccessory")}
                         {this.renderMemberCheckBox("Eyewear", "eyewear")}
                         {this.renderMemberCheckBox("Body accessory", "body")}
                         {this.renderMemberCheckBox("Back accessory", "back")}
+                        {this.renderMemberCheckBox("Background", "background")}
+                        {this.renderMemberCheckBox("Mount", "mount")}
                     </View>
                 </View>
             </View>
         );
     }
 
-    private renderMemberCheckBox(caption: string, slot: GearSlot) {
+    private renderMemberCheckBox(caption: string, slot: OutfitSlot) {
         const onPress = (value: boolean) => this.props.updateGearSet(slot, value);
         return <CheckBoxButton caption={caption} onPress={onPress} value={this.props.gearChecklist[slot]}/>;
     }

--- a/src/items/Equipper.ts
+++ b/src/items/Equipper.ts
@@ -6,35 +6,48 @@ export default class Equipper {
     gearType: "equipped" | "costume";
     newOutfit: IOutfit;
     currentOutfit: IOutfit;
-    failMessage = "";
 
     constructor(outfit: IOutfit, useCostume: boolean, userData: IHabiticaData) {
         this.gearType = useCostume ? "costume" : "equipped";
         this.newOutfit = outfit;
         const gear = userData.items.gear;
-        this.currentOutfit = { name: "current", gearSet: useCostume ? gear.costume : gear.equipped };
+        this.currentOutfit = {
+            name: "current",
+            gearSet: useCostume ? gear.costume : gear.equipped,
+            skin: userData.preferences.skin,
+            background: userData.preferences.background,
+            pet: userData.items.currentPet,
+            mount: userData.items.currentMount,
+        };
     }
 
     async equipAll(): Promise<string> {
-        await this.equipItem("armor", this.newOutfit.gearSet.armor);
-        await this.equipItem("head", this.newOutfit.gearSet.head);
-        await this.equipItem("shield", this.newOutfit.gearSet.shield);
-        await this.equipItem("body", this.newOutfit.gearSet.body);
-        await this.equipItem("weapon", this.newOutfit.gearSet.weapon);
-        await this.equipItem("eyewear", this.newOutfit.gearSet.eyewear);
-        await this.equipItem("headAccessory", this.newOutfit.gearSet.headAccessory);
-        await this.equipItem("back", this.newOutfit.gearSet.back);
-        return this.failMessage || `${this.newOutfit.name} equipped successfully.`;
+        const failMessage = [
+            await this.equipItem("armor"),
+            await this.equipItem("head"),
+            await this.equipItem("shield"),
+            await this.equipItem("body"),
+            await this.equipItem("weapon"),
+            await this.equipItem("eyewear"),
+            await this.equipItem("headAccessory"),
+            await this.equipItem("back"),
+            await this.equip("pet", this.newOutfit.pet, this.currentOutfit.pet),
+            await this.equip("mount", this.newOutfit.mount, this.currentOutfit.mount),
+        ].filter(Boolean).join("\n");
+        return failMessage || `${this.newOutfit.name} equipped successfully.`;
     }
 
-    async equipItem(slot: "armor" | "head" | "shield" | "body" | "weapon" | "eyewear" | "headAccessory" | "back", item?: string): Promise<void> {
-        const currentItem = this.currentOutfit.gearSet[slot];
-        if (item && item !== currentItem) {
-            const newItem = item.endsWith("_base_0") ? currentItem : item; // Unequip current item if the outfit slot is explicitly empty.
+    async equipItem(type: "armor" | "head" | "shield" | "body" | "weapon" | "eyewear" | "headAccessory" | "back" ): Promise<string | undefined> {
+        return await this.equip(this.gearType, this.newOutfit.gearSet[type], this.currentOutfit.gearSet[type]);
+    }
+
+    async equip(type: "mount" | "pet" | "costume" | "equipped", newItem?: string, currentItem?: string): Promise<string | undefined> {
+        if (newItem && newItem !== currentItem) {
+            const toBeEquipped = newItem.endsWith("_base_0") ? currentItem : newItem; // Unequip current item if the outfit slot is explicitly empty.
             try {
-                await callHabApi(`/api/v3/user/equip/${this.gearType}/${newItem}`, "POST");
+                await callHabApi(`/api/v3/user/equip/${type}/${toBeEquipped}`, "POST");
             } catch (e) {
-                this.failMessage += `Failed to equip ${item}: ${e.message}\n`;
+                return `Failed to (un)equip ${newItem}: ${e.message}`;
             }
         }
     }

--- a/src/items/Equipper.ts
+++ b/src/items/Equipper.ts
@@ -1,5 +1,5 @@
 import { callHabApi } from "../requests/HabiticaRequest";
-import IHabiticaData from "../userData/IHabiticaData";
+import IHabiticaData, { IHair } from "../userData/IHabiticaData";
 import IOutfit from "./IOutfit";
 
 export default class Equipper {
@@ -15,6 +15,7 @@ export default class Equipper {
             name: "current",
             gearSet: useCostume ? gear.costume : gear.equipped,
             skin: userData.preferences.skin,
+            hair: userData.preferences.hair,
             background: userData.preferences.background,
             pet: userData.items.currentPet,
             mount: userData.items.currentMount,
@@ -33,7 +34,7 @@ export default class Equipper {
             await this.equipItem("back"),
             await this.equip("pet", this.newOutfit.pet, this.currentOutfit.pet),
             await this.equip("mount", this.newOutfit.mount, this.currentOutfit.mount),
-            await this.setPreferences(this.newOutfit.background, this.newOutfit.skin),
+            await this.setPreferences(),
         ].filter(Boolean).join("\n");
         return failMessage || `${this.newOutfit.name} equipped successfully.`;
     }
@@ -53,24 +54,34 @@ export default class Equipper {
         }
     }
 
-    async setPreferences(background?: string, skin?: string): Promise<string | undefined> {
+    async setPreferences(): Promise<string | undefined> {
         const body: any = {};
-        let failMessage = "Failed to equip ";
 
+        const background = this.newOutfit.background;
         if (background && background !== this.currentOutfit.background) {
             body["preferences.background"] = background;
-            failMessage += background;
         }
+
+        const skin = this.newOutfit.skin;
         if (skin && skin !== this.currentOutfit.skin) {
             body["preferences.skin"] = skin;
-            failMessage += background ? ` and ${skin}` : skin;
+        }
+
+        const hair = this.newOutfit.hair;
+        if (hair && hair !== this.currentOutfit.hair) {
+            body["preferences.hair.color"] = hair.color;
+            body["preferences.hair.base"] = hair.base;
+            body["preferences.hair.bangs"] = hair.bangs;
+            body["preferences.hair.beard"] = hair.beard;
+            body["preferences.hair.mustache"] = hair.mustache;
+            body["preferences.hair.flower"] = hair.flower;
         }
 
         if (Object.keys(body).length > 0) {
             try {
                 await callHabApi(`/api/v4/user`, "PUT", body);
             } catch (e) {
-                return `${failMessage}: ${e.message}`;
+                return `Failed to equip background, skin, and/or hair: ${e.message}`;
             }
         }
     }

--- a/src/items/Equipper.ts
+++ b/src/items/Equipper.ts
@@ -2,7 +2,7 @@ import { callHabApi } from "../requests/HabiticaRequest";
 import IHabiticaData from "../userData/IHabiticaData";
 import IOutfit from "./IOutfit";
 
-export default class Outfitter {
+export default class Equipper {
     gearType: "equipped" | "costume";
     newOutfit: IOutfit;
     currentOutfit: IOutfit;

--- a/src/items/Equipper.ts
+++ b/src/items/Equipper.ts
@@ -68,13 +68,25 @@ export default class Equipper {
         }
 
         const hair = this.newOutfit.hair;
-        if (hair && hair !== this.currentOutfit.hair) {
-            body["preferences.hair.color"] = hair.color;
-            body["preferences.hair.base"] = hair.base;
-            body["preferences.hair.bangs"] = hair.bangs;
-            body["preferences.hair.beard"] = hair.beard;
-            body["preferences.hair.mustache"] = hair.mustache;
-            body["preferences.hair.flower"] = hair.flower;
+        if (hair) {
+            if (hair.color !== this.currentOutfit.hair!.color) {
+                body["preferences.hair.color"] = hair.color;
+            }
+            if (hair.base !== this.currentOutfit.hair!.base) {
+                body["preferences.hair.base"] = hair.base;
+            }
+            if (hair.bangs !== this.currentOutfit.hair!.bangs) {
+                body["preferences.hair.bangs"] = hair.bangs;
+            }
+            if (hair.beard !== this.currentOutfit.hair!.beard) {
+                body["preferences.hair.beard"] = hair.beard;
+            }
+            if (hair.mustache !== this.currentOutfit.hair!.mustache) {
+                body["preferences.hair.mustache"] = hair.mustache;
+            }
+            if (hair.flower !== this.currentOutfit.hair!.flower) {
+                body["preferences.hair.flower"] = hair.flower;
+            }
         }
 
         if (Object.keys(body).length > 0) {

--- a/src/items/Equipper.ts
+++ b/src/items/Equipper.ts
@@ -33,6 +33,7 @@ export default class Equipper {
             await this.equipItem("back"),
             await this.equip("pet", this.newOutfit.pet, this.currentOutfit.pet),
             await this.equip("mount", this.newOutfit.mount, this.currentOutfit.mount),
+            await this.setPreferences(this.newOutfit.background, this.newOutfit.skin),
         ].filter(Boolean).join("\n");
         return failMessage || `${this.newOutfit.name} equipped successfully.`;
     }
@@ -48,6 +49,28 @@ export default class Equipper {
                 await callHabApi(`/api/v3/user/equip/${type}/${toBeEquipped}`, "POST");
             } catch (e) {
                 return `Failed to (un)equip ${newItem}: ${e.message}`;
+            }
+        }
+    }
+
+    async setPreferences(background?: string, skin?: string): Promise<string | undefined> {
+        const body: any = {};
+        let failMessage = "Failed to equip ";
+
+        if (background && background !== this.currentOutfit.background) {
+            body["preferences.background"] = background;
+            failMessage += background;
+        }
+        if (skin && skin !== this.currentOutfit.skin) {
+            body["preferences.skin"] = skin;
+            failMessage += background ? ` and ${skin}` : skin;
+        }
+
+        if (Object.keys(body).length > 0) {
+            try {
+                await callHabApi(`/api/v4/user`, "PUT", body);
+            } catch (e) {
+                return `${failMessage}: ${e.message}`;
             }
         }
     }

--- a/src/items/GearSlot.ts
+++ b/src/items/GearSlot.ts
@@ -1,1 +1,0 @@
-export type GearSlot = "armor" | "head" | "shield" | "body" | "weapon" | "headAccessory" | "eyewear" | "back";

--- a/src/items/IOutfit.ts
+++ b/src/items/IOutfit.ts
@@ -3,4 +3,8 @@ import { IGearSet } from "../userData/IHabiticaData";
 export default interface IOutfit {
     name: string;
     gearSet: IGearSet;
+    skin?: string;
+    background?: string;
+    pet?: string;
+    mount?: string;
 }

--- a/src/items/IOutfit.ts
+++ b/src/items/IOutfit.ts
@@ -1,9 +1,10 @@
-import { IGearSet } from "../userData/IHabiticaData";
+import { IGearSet, IHair } from "../userData/IHabiticaData";
 
 export default interface IOutfit {
     name: string;
     gearSet: IGearSet;
     skin?: string;
+    hair?: IHair;
     background?: string;
     pet?: string;
     mount?: string;

--- a/src/items/OutfitChecklist.ts
+++ b/src/items/OutfitChecklist.ts
@@ -8,6 +8,7 @@ export default class OutfitChecklist {
     headAccessory = true;
     back = true;
     skin = true;
+    hair = true;
     background = true;
     pet = true;
     mount = true;

--- a/src/items/OutfitChecklist.ts
+++ b/src/items/OutfitChecklist.ts
@@ -1,4 +1,4 @@
-export default class GearChecklist {
+export default class OutfitChecklist {
     armor = true;
     head = true;
     shield = true;
@@ -7,4 +7,8 @@ export default class GearChecklist {
     eyewear = true;
     headAccessory = true;
     back = true;
+    skin = true;
+    background = true;
+    pet = true;
+    mount = true;
 }

--- a/src/items/OutfitMaker.ts
+++ b/src/items/OutfitMaker.ts
@@ -1,0 +1,38 @@
+import WardrobeStore from "../store/WardrobeStore";
+import IHabiticaData from "../userData/IHabiticaData";
+import IOutfit from "./IOutfit";
+import OutfitChecklist from "./OutfitChecklist";
+
+export default class OutfitMaker {
+    userData: Promise<IHabiticaData>;
+    checklist: OutfitChecklist;
+
+    constructor(userData: Promise<IHabiticaData>) {
+        this.userData = userData;
+        this.checklist = new OutfitChecklist();
+    }
+
+    async save(name: string, useCostume: boolean): Promise<string> {
+        const data = await this.userData;
+        const rawGearSet = data.items.gear[useCostume ? "costume" : "equipped"];
+        const outfit: IOutfit = {
+            name,
+            gearSet: {
+                armor: this.checklist.armor ? rawGearSet.armor : undefined,
+                head: this.checklist.head ? rawGearSet.head : undefined,
+                shield: this.checklist.shield ? rawGearSet.shield : undefined,
+                body: this.checklist.body ? rawGearSet.body : undefined,
+                weapon: this.checklist.weapon ? rawGearSet.weapon : undefined,
+                eyewear: this.checklist.eyewear ? rawGearSet.eyewear : undefined,
+                headAccessory: this.checklist.headAccessory ? rawGearSet.headAccessory : undefined,
+                back: this.checklist.back ? rawGearSet.back : undefined,
+            },
+            skin: this.checklist.skin ? data.preferences.skin : undefined,
+            background: this.checklist.background ? data.preferences.background : undefined,
+            pet: this.checklist.pet ? data.items.currentPet : undefined,
+            mount: this.checklist.mount ? data.items.currentMount : undefined,
+        };
+        await WardrobeStore.add(outfit);
+        return `Successfully added ${name} to your wardrobe.`;
+    }
+}

--- a/src/items/OutfitMaker.ts
+++ b/src/items/OutfitMaker.ts
@@ -28,6 +28,7 @@ export default class OutfitMaker {
                 back: this.checklist.back ? rawGearSet.back : undefined,
             },
             skin: this.checklist.skin ? data.preferences.skin : undefined,
+            hair: this.checklist.hair ? data.preferences.hair : undefined,
             background: this.checklist.background ? data.preferences.background : undefined,
             pet: this.checklist.pet ? data.items.currentPet : undefined,
             mount: this.checklist.mount ? data.items.currentMount : undefined,

--- a/src/items/OutfitSlot.ts
+++ b/src/items/OutfitSlot.ts
@@ -1,0 +1,13 @@
+export type OutfitSlot =
+    "armor"
+    | "head"
+    | "shield"
+    | "body"
+    | "weapon"
+    | "headAccessory"
+    | "eyewear"
+    | "back"
+    | "skin"
+    | "background"
+    | "pet"
+    | "mount";

--- a/src/items/OutfitSlot.ts
+++ b/src/items/OutfitSlot.ts
@@ -8,6 +8,7 @@ export type OutfitSlot =
     | "eyewear"
     | "back"
     | "skin"
+    | "hair"
     | "background"
     | "pet"
     | "mount";

--- a/src/requests/HabiticaRequest.ts
+++ b/src/requests/HabiticaRequest.ts
@@ -1,7 +1,7 @@
 import { getEnv } from "../config";
 import { getCredentials } from "../store/CredentialStore";
 
-export async function callHabApi(apiSuffix: string, method: "POST" | "GET", body?: any): Promise<any> {
+export async function callHabApi(apiSuffix: string, method: "POST" | "GET" | "PUT", body?: any): Promise<any> {
     const credentials = await getCredentials();
     const headers: any = {
         "x-client": "probaton-habotica",

--- a/src/userData/IHabiticaData.ts
+++ b/src/userData/IHabiticaData.ts
@@ -38,6 +38,7 @@ export default interface IHabiticaData {
     preferences: {
         background: string;
         skin: string;
+        hair: IHair,
     };
 }
 
@@ -52,6 +53,15 @@ export interface IGearSet {
     eyewear?: string;
     headAccessory?: string;
     back?: string;
+}
+
+export interface IHair {
+    color: string;
+    base: string;
+    bangs: string;
+    beard: string;
+    mustache: string;
+    flower: string;
 }
 
 export interface IHabit {

--- a/src/userData/IHabiticaData.ts
+++ b/src/userData/IHabiticaData.ts
@@ -32,6 +32,12 @@ export default interface IHabiticaData {
             equipped: IGearSet;
             costume: IGearSet;
         }
+        currentPet?: string;
+        currentMount?: string;
+    };
+    preferences: {
+        background: string;
+        skin: string;
     };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
         "jsx": "react-native",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
         "outDir": "./out",                        /* Redirect output structure to the directory. */
-        "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
         "strict": true,                           /* Enable all strict type-checking options. */
         "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
         "lib": ["es2015"]


### PR DESCRIPTION
- Add mounts, pets, backgrounds, skin, and hair to the options available in outfits. These slots can now be saved and equipped in the wardrobe. 
- Rename `Outfitter` to `Equipper` and abstracted saving outfits into `OutfitMaker`. 
 
Fixes #38 